### PR TITLE
增加 Windows 数据线连接模式

### DIFF
--- a/electron/appMain.ts
+++ b/electron/appMain.ts
@@ -17,6 +17,7 @@ import { DEFAULT_HOST, LunaClient } from './lunaProtocol'
 import { GoUltraClient } from './goUltraProtocol'
 import { LunaUltraProtocol, GoUltraProtocol } from './deviceProtocols'
 import { DEFAULT_DEVICE, GO_ULTRA_DEVICE, deviceDefinitionFor } from './deviceDefaults'
+import { listUsbStorageFiles, scanUsbStorageVolumes } from './usbStorageService'
 import { deviceProfileForId } from '../src/shared/insta360DeviceProfiles'
 import { mockTcpPortForHost, stopMockServer } from './mockServerService'
 import { createPreviewTaskQueue } from './previewTaskQueue'
@@ -51,8 +52,8 @@ process.env.VITE_PUBLIC = VITE_DEV_SERVER_URL ? path.join(process.env.APP_ROOT, 
 let win: BrowserWindow | null
 const clients = new Map<string, LunaClient>()
 const goUltraClients = new Map<string, GoUltraClient>()
-let activeDownloadControllers = new Set<AbortController>()
-let activeExportControllers = new Map<string, AbortController>()
+const activeDownloadControllers = new Set<AbortController>()
+const activeExportControllers = new Map<string, AbortController>()
 const activeExportEncoders = new Map<string, import('node:child_process').ChildProcessWithoutNullStreams>()
 const previewCacheTasks = new Map<string, Promise<boolean>>()
 const videoFrameRateTasks = new Map<string, Promise<number | null>>()
@@ -262,7 +263,7 @@ function registerIpc(): void {
   } as const
   const ipcModules = import.meta.glob('./ipc*.ts', { eager: true })
   for (const [, mod] of Object.entries(ipcModules)) {
-    const fn = (mod as any).register
+    const fn = (mod as { register?: (context: typeof ctx) => void }).register
     if (typeof fn === 'function') fn(ctx)
   }
 
@@ -281,8 +282,27 @@ function registerIpc(): void {
   ipcMain.handle('device:connect', async (_event, options?: DeviceConnectOptions) => {
     const settings = await getSettings()
     const deviceId = options?.deviceId ?? settings.activeDeviceId ?? DEFAULT_DEVICE.id
+    const mode = options?.mode ?? settings.connectionMode ?? 'wifi'
     const host = options?.host || settings.cameraHost || DEFAULT_HOST
-    logMainInfo(`[设备连接] 开始连接设备`, { deviceId, host, options })
+    logMainInfo(`[设备连接] 开始连接设备`, { deviceId, host, mode, options })
+
+    if (mode === 'usb') {
+      const volumes = await scanUsbStorageVolumes()
+      await saveSettings({ connectionMode: 'usb' })
+      const status = {
+        deviceId,
+        deviceName: deviceDefinitionFor(deviceId).name,
+        host: '本地 USB',
+        httpOk: false,
+        controlOk: false,
+        mode,
+        usbOk: volumes.length > 0,
+        usbStorageCount: volumes.length,
+        message: volumes.length > 0 ? `已检测到 ${volumes.length} 个数据线存储` : '暂未识别到数据线存储',
+      }
+      logMainInfo(`[设备连接] USB 检测结果`, { deviceId, usbStorageCount: volumes.length, usbOk: status.usbOk })
+      return status
+    }
 
     // 根据设备 ID 路由到对应协议
     let protocol: LunaUltraProtocol | GoUltraProtocol
@@ -298,8 +318,9 @@ function registerIpc(): void {
 
     try {
       const status = await protocol.connect({ ...options, deviceId })
+      await saveSettings({ connectionMode: 'wifi' })
       logMainInfo(`[设备连接] 连接结果`, { deviceId, host, httpOk: status.httpOk, controlOk: status.controlOk, message: status.message })
-      return status
+      return { ...status, mode: 'wifi' }
     } catch (error) {
       logMainError(`[设备连接] 连接异常`, { deviceId, host, error: error instanceof Error ? error.message : String(error) })
       throw error
@@ -334,27 +355,33 @@ function registerIpc(): void {
     const settings = await getSettings()
     const normalizedHost = host || settings.cameraHost
     const deviceId = settings.activeDeviceId ?? DEFAULT_DEVICE.id
+    const mode = settings.connectionMode ?? 'wifi'
     const nextStorageId = storageId ?? settings.deviceStorage?.[deviceId] ?? 'all'
-    logMainInfo(`[HTTP读取] 开始读取文件列表`, { host: normalizedHost, storageId: nextStorageId, deviceId })
+    logMainInfo(`[媒体读取] 开始读取文件列表`, { host: normalizedHost, storageId: nextStorageId, deviceId, mode })
     const t0 = performance.now()
     try {
       let files: LunaFile[]
-      switch (deviceId) {
-        case 'go-ultra': {
-          const protocol = goUltraProtocol()
-          files = await protocol.listFiles({ deviceId, host: normalizedHost, storageId: nextStorageId })
-          break
-        }
-        default: {
-          const protocol = lunaProtocol()
-          files = await protocol.listFiles({ deviceId, host: normalizedHost, storageId: nextStorageId })
+      if (mode === 'usb') {
+        files = await listUsbStorageFiles(nextStorageId)
+      } else {
+        switch (deviceId) {
+          case 'go-ultra': {
+            const protocol = goUltraProtocol()
+            files = await protocol.listFiles({ deviceId, host: normalizedHost, storageId: nextStorageId })
+            break
+          }
+          default: {
+            const protocol = lunaProtocol()
+            files = await protocol.listFiles({ deviceId, host: normalizedHost, storageId: nextStorageId })
+          }
         }
       }
       files = attachSourceDevice(files, deviceId)
       const elapsed = ((performance.now() - t0) / 1000).toFixed(2)
-      logMainInfo(`[HTTP读取] 文件列表读取完成`, { host: normalizedHost, storageId: nextStorageId, fileCount: files.length, elapsedSec: elapsed })
+      logMainInfo(`[媒体读取] 文件列表读取完成`, { host: normalizedHost, storageId: nextStorageId, fileCount: files.length, elapsedSec: elapsed, mode })
       await saveSettings({
         cameraHost: normalizedHost,
+        connectionMode: mode,
         deviceStorage: {
           ...(settings.deviceStorage ?? {}),
           [deviceId]: nextStorageId,
@@ -367,7 +394,7 @@ function registerIpc(): void {
       }
       return files
     } catch (error) {
-      logMainError(`[HTTP读取] 文件列表读取失败`, { host: normalizedHost, storageId: nextStorageId, error: error instanceof Error ? error.message : String(error) })
+      logMainError(`[媒体读取] 文件列表读取失败`, { host: normalizedHost, storageId: nextStorageId, mode, error: error instanceof Error ? error.message : String(error) })
       throw error
     }
   })

--- a/electron/deviceDefaults.ts
+++ b/electron/deviceDefaults.ts
@@ -1,6 +1,7 @@
 import lunaUltraConfig from './deviceConfigs/luna-ultra.json'
 import goUltraConfig from './deviceConfigs/go-ultra.json'
 import type { DeviceDefinition } from '../src/shared/types'
+import { scanUsbStorageVolumes, usbStorageOptions } from './usbStorageService'
 
 export const DEFAULT_DEVICE = lunaUltraConfig as DeviceDefinition
 export const GO_ULTRA_DEVICE = goUltraConfig as DeviceDefinition
@@ -22,4 +23,20 @@ export function deviceDefinitions(): DeviceDefinition[] {
     DEFAULT_DEVICE,
     GO_ULTRA_DEVICE,
   ]
+}
+
+export async function deviceDefinitionsWithUsbStorage(): Promise<DeviceDefinition[]> {
+  const definitions = deviceDefinitions().map((device) => ({ ...device, storages: [...device.storages] }))
+  if (process.platform !== 'win32') return definitions
+
+  const volumes = await scanUsbStorageVolumes().catch(() => [])
+  if (volumes.length === 0) return definitions
+
+  return definitions.map((device) => {
+    if (device.id !== DEFAULT_DEVICE.id) return device
+    const dynamicOptions = usbStorageOptions(volumes)
+    const existing = new Map(device.storages.map((storage) => [storage.id, storage]))
+    for (const option of dynamicOptions) existing.set(option.id, option)
+    return { ...device, storages: [...existing.values()] }
+  })
 }

--- a/electron/ipcConnectivityService.ts
+++ b/electron/ipcConnectivityService.ts
@@ -1,6 +1,8 @@
 import { BrowserWindow, ipcMain } from 'electron'
 import type { LunaFile, WifiConnectOptions, WifiHttpRequestOptions, WifiPortCheckOptions } from '../src/shared/types'
 import { cancelBluetoothScan, scanBluetoothDevices } from './bluetoothDebugService'
+import { scanUsbDevices } from './usbDeviceService'
+import { scanUsbStorageDevices } from './usbStorageService'
 import {
   checkWifiPort,
   connectWifiNetwork,
@@ -11,10 +13,9 @@ import {
 } from './wifiDebugService'
 import { openWifiSettings } from './wifiService'
 import { getDownloadedRecords, getLocalResourcesDir, getSettings } from './fileService'
-import type { IpcContext } from './ipcContext'
 
-export function register(_ctx?: IpcContext): void {
-  ipcMain.handle('downloads:records', async (_event, files: LunaFile[], _downloadDir?: string) => {
+export function register(): void {
+  ipcMain.handle('downloads:records', async (_event, files: LunaFile[]) => {
     const settings = await getSettings()
     return getDownloadedRecords(files, getLocalResourcesDir(settings))
   })
@@ -36,6 +37,14 @@ export function register(_ctx?: IpcContext): void {
 
   ipcMain.handle('bluetooth:cancelScan', () => {
     cancelBluetoothScan()
+  })
+
+  ipcMain.handle('usb:scan', async () => {
+    const [devices, storageDevices] = await Promise.all([
+      scanUsbDevices().catch(() => []),
+      scanUsbStorageDevices().catch(() => []),
+    ])
+    return [...devices, ...storageDevices]
   })
 
   ipcMain.handle('devtools:open', () => {

--- a/electron/ipcSettingsService.ts
+++ b/electron/ipcSettingsService.ts
@@ -1,17 +1,16 @@
 import { ipcMain } from 'electron'
 import type { AppSettings } from '../src/shared/types'
-import { deviceDefinitions } from './deviceDefaults'
+import { deviceDefinitionsWithUsbStorage } from './deviceDefaults'
 import {
   chooseDownloadDir, chooseLocalResourcesDir, chooseExportDir, chooseMockMediaDir,
   getSettings, saveSettings, getCacheStats, clearCache,
 } from './fileService'
 import { startMockServer, stopMockServer, getMockStatus } from './mockServerService'
-import type { IpcContext } from './ipcContext'
 
-export function register(_ctx?: IpcContext): void {
+export function register(): void {
   ipcMain.handle('settings:get', () => getSettings())
   ipcMain.handle('settings:save', (_event, settings: Partial<AppSettings>) => saveSettings(settings))
-  ipcMain.handle('devices:list', () => deviceDefinitions())
+  ipcMain.handle('devices:list', () => deviceDefinitionsWithUsbStorage())
   ipcMain.handle('settings:chooseDownloadDir', () => chooseDownloadDir())
   ipcMain.handle('settings:chooseLocalResourcesDir', () => chooseLocalResourcesDir())
   ipcMain.handle('settings:chooseExportDir', () => chooseExportDir())

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -48,6 +48,7 @@ const lunaApi: LunaApi = {
   openDevTools: () => ipcRenderer.invoke('devtools:open'),
   scanBluetoothDevices: (timeoutMs?: number) => ipcRenderer.invoke('bluetooth:scanNative', timeoutMs),
   cancelBluetoothScan: () => ipcRenderer.invoke('bluetooth:cancelScan'),
+  scanUsbDevices: () => ipcRenderer.invoke('usb:scan'),
   connectDevice: (options?: DeviceConnectOptions) => ipcRenderer.invoke('device:connect', options),
   checkConnection: (host?: string) => ipcRenderer.invoke('luna:checkConnection', host),
   listFiles: (host?: string, storageId?: string) => ipcRenderer.invoke('luna:listFiles', host, storageId),

--- a/electron/usbDeviceService.ts
+++ b/electron/usbDeviceService.ts
@@ -1,0 +1,204 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import type { UsbDeviceCandidate } from '../src/shared/types'
+
+const execFileAsync = promisify(execFile)
+
+interface SystemProfilerUsbNode {
+  _name?: string
+  manufacturer?: string
+  serial_num?: string
+  vendor_id?: string
+  product_id?: string
+  bcd_device?: string
+  Media?: unknown
+  _items?: SystemProfilerUsbNode[]
+}
+
+interface SystemProfilerUsbPayload {
+  SPUSBDataType?: SystemProfilerUsbNode[]
+}
+
+interface WindowsPnpDevice {
+  FriendlyName?: string
+  InstanceId?: string
+  Manufacturer?: string
+  Class?: string
+  Status?: string
+}
+
+const CAMERA_KEYWORDS = [
+  'insta360',
+  'arashi',
+  'luna',
+  'ptp',
+  'mtp',
+  'still image',
+  'digital still camera',
+]
+
+function isAppleInternalDevice(name: string, manufacturer: string, busName: string): boolean {
+  const text = `${name} ${manufacturer} ${busName}`.toLowerCase()
+  return text.includes('apple') || text.includes('built-in') || text.includes('internal')
+}
+
+function matchesCameraDevice(name: string, manufacturer: string, busName: string, searchText: string): boolean {
+  if (CAMERA_KEYWORDS.some((keyword) => searchText.includes(keyword))) return true
+  if (!searchText.includes('camera')) return false
+  return !isAppleInternalDevice(name, manufacturer, busName)
+}
+
+function normalizeText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function flattenUsbNodes(nodes: SystemProfilerUsbNode[] | undefined, busName = ''): UsbDeviceCandidate[] {
+  if (!nodes?.length) return []
+
+  const result: UsbDeviceCandidate[] = []
+  for (const node of nodes) {
+    const name = normalizeText(node._name)
+    const manufacturer = normalizeText(node.manufacturer)
+    const serialNumber = normalizeText(node.serial_num)
+    const vendorId = normalizeText(node.vendor_id)
+    const productId = normalizeText(node.product_id)
+    const productVersion = normalizeText(node.bcd_device)
+    const currentBusName = name && !vendorId && !productId ? name : busName
+    const searchText = [
+      name,
+      manufacturer,
+      serialNumber,
+      vendorId,
+      productId,
+      currentBusName,
+      node.Media ? 'media' : '',
+    ].join(' ').toLowerCase()
+
+    if (name && (vendorId || productId || manufacturer)) {
+      const matched = matchesCameraDevice(name, manufacturer, currentBusName, searchText)
+      if (matched) {
+        result.push({
+          id: `${vendorId || 'unknown'}:${productId || 'unknown'}:${serialNumber || name}`,
+          name,
+          manufacturer,
+          serialNumber,
+          vendorId,
+          productId,
+          productVersion,
+          busName: currentBusName,
+          transport: 'usb',
+          matched,
+          source: 'system_profiler',
+        })
+      }
+    }
+
+    result.push(...flattenUsbNodes(node._items, currentBusName))
+  }
+  return result
+}
+
+function uniqueDevices(devices: UsbDeviceCandidate[]): UsbDeviceCandidate[] {
+  const seen = new Set<string>()
+  return devices.filter((device) => {
+    const key = `${device.vendorId}:${device.productId}:${device.serialNumber}:${device.name}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+async function scanMacUsbDevices(): Promise<UsbDeviceCandidate[]> {
+  const { stdout } = await execFileAsync('/usr/sbin/system_profiler', ['SPUSBDataType', '-json'], {
+    maxBuffer: 8 * 1024 * 1024,
+    timeout: 15_000,
+  })
+  const payload = JSON.parse(stdout) as SystemProfilerUsbPayload
+  return uniqueDevices(flattenUsbNodes(payload.SPUSBDataType))
+}
+
+function parseWindowsVidPid(instanceId: string): { vendorId?: string; productId?: string; serialNumber?: string } {
+  const vid = instanceId.match(/VID_([0-9A-F]{4})/i)?.[1]
+  const pid = instanceId.match(/PID_([0-9A-F]{4})/i)?.[1]
+  const parts = instanceId.split('\\')
+  const serialNumber = parts.length > 2 ? parts[parts.length - 1] : undefined
+  return {
+    vendorId: vid ? `0x${vid.toLowerCase()}` : undefined,
+    productId: pid ? `0x${pid.toLowerCase()}` : undefined,
+    serialNumber,
+  }
+}
+
+function normalizeWindowsPnpPayload(stdout: string): WindowsPnpDevice[] {
+  const text = stdout.trim()
+  if (!text) return []
+  const parsed = JSON.parse(text) as WindowsPnpDevice | WindowsPnpDevice[]
+  return Array.isArray(parsed) ? parsed : [parsed]
+}
+
+function windowsPnpDeviceToCandidate(device: WindowsPnpDevice): UsbDeviceCandidate | null {
+  const name = normalizeText(device.FriendlyName)
+  const instanceId = normalizeText(device.InstanceId)
+  const manufacturer = normalizeText(device.Manufacturer)
+  const deviceClass = normalizeText(device.Class)
+  const status = normalizeText(device.Status)
+  if (!name || !instanceId) return null
+
+  const searchText = [name, manufacturer, deviceClass, instanceId, status].join(' ').toLowerCase()
+  const isLikelyUsbTransport = instanceId.toUpperCase().startsWith('USB') || searchText.includes('mtp') || searchText.includes('ptp')
+  if (!isLikelyUsbTransport) return null
+  if (!matchesCameraDevice(name, manufacturer, deviceClass, searchText)) return null
+
+  const ids = parseWindowsVidPid(instanceId)
+  return {
+    id: instanceId,
+    name,
+    manufacturer,
+    serialNumber: ids.serialNumber,
+    vendorId: ids.vendorId,
+    productId: ids.productId,
+    busName: deviceClass,
+    transport: 'usb',
+    matched: true,
+    source: 'powershell',
+  }
+}
+
+async function scanWindowsUsbDevices(): Promise<UsbDeviceCandidate[]> {
+  const script = [
+    '$ErrorActionPreference = "Stop"',
+    '$classes = @("Camera", "Image", "WPD", "USB")',
+    '$devices = Get-PnpDevice -PresentOnly | Where-Object {',
+    '  $name = [string]$_.FriendlyName',
+    '  $id = [string]$_.InstanceId',
+    '  $class = [string]$_.Class',
+    '  $text = "$name $id $class"',
+    '  $id -like "USB*" -or $classes -contains $class -or $text -match "Insta360|Luna|PTP|MTP|Still Image|Digital Still Camera|Camera"',
+    '} | Select-Object FriendlyName,InstanceId,Manufacturer,Class,Status',
+    '$devices | ConvertTo-Json -Compress',
+  ].join('; ')
+
+  const { stdout } = await execFileAsync('powershell.exe', [
+    '-NoProfile',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-Command',
+    script,
+  ], {
+    maxBuffer: 8 * 1024 * 1024,
+    timeout: 15_000,
+    windowsHide: true,
+  })
+
+  return uniqueDevices(
+    normalizeWindowsPnpPayload(stdout)
+      .map(windowsPnpDeviceToCandidate)
+      .filter((device): device is UsbDeviceCandidate => Boolean(device)),
+  )
+}
+
+export async function scanUsbDevices(): Promise<UsbDeviceCandidate[]> {
+  if (process.platform === 'darwin') return scanMacUsbDevices()
+  if (process.platform === 'win32') return scanWindowsUsbDevices()
+  return []
+}

--- a/electron/usbStorageService.ts
+++ b/electron/usbStorageService.ts
@@ -1,0 +1,277 @@
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+import { lunaMediaAdapter } from './deviceMedia'
+import { labelsFor } from './filePathUtils'
+import type { DeviceStorageOption, LunaFile, UsbDeviceCandidate } from '../src/shared/types'
+
+const execFileAsync = promisify(execFile)
+
+interface WindowsLogicalDisk {
+  DeviceID?: string
+  VolumeName?: string
+  FileSystem?: string
+  DriveType?: number
+  FreeSpace?: number | string | null
+  Size?: number | string | null
+}
+
+export interface UsbStorageVolume {
+  storageId: string
+  label: string
+  rootPath: string
+  mediaRoot: string
+  freeBytes: number | null
+  totalBytes: number | null
+}
+
+const MEDIA_EXTENSIONS = new Set([
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.dng',
+  '.insp',
+  '.mp4',
+  '.mov',
+  '.insv',
+  '.lrv',
+  '.liv',
+])
+
+function toNumber(value: number | string | null | undefined): number | null {
+  if (value == null || value === '') return null
+  const number = Number(value)
+  return Number.isFinite(number) ? number : null
+}
+
+function storageIdForVolume(label: string, rootPath: string): string {
+  const normalized = `${label} ${rootPath}`.toLowerCase()
+  if (normalized.includes('internal')) return 'storage_internal'
+  if (normalized.includes('sd') || normalized.includes('luna')) return 'sdcard'
+  return `usb_${rootPath.replace(/[^a-z0-9]/gi, '').toLowerCase()}`
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function resolveMediaRoot(rootPath: string): Promise<string | null> {
+  const candidates = [
+    path.join(rootPath, 'DCIM', 'Camera01'),
+    path.join(rootPath, 'DCIM', '100MEDIA'),
+    path.join(rootPath, 'DCIM'),
+  ]
+  for (const candidate of candidates) {
+    if (await pathExists(candidate)) return candidate
+  }
+  return null
+}
+
+function normalizeWindowsDriveRoot(deviceId: string): string {
+  return deviceId.endsWith('\\') ? deviceId : `${deviceId}\\`
+}
+
+function normalizeWindowsDiskPayload(stdout: string): WindowsLogicalDisk[] {
+  const text = stdout.trim()
+  if (!text) return []
+  const parsed = JSON.parse(text) as WindowsLogicalDisk | WindowsLogicalDisk[]
+  return Array.isArray(parsed) ? parsed : [parsed]
+}
+
+async function windowsLogicalDisks(): Promise<WindowsLogicalDisk[]> {
+  const script = [
+    '$ErrorActionPreference = "Stop";',
+    'Get-CimInstance Win32_LogicalDisk |',
+    'Where-Object { $_.DriveType -eq 2 -or $_.DriveType -eq 3 } |',
+    'Select-Object DeviceID,VolumeName,FileSystem,DriveType,FreeSpace,Size |',
+    'ConvertTo-Json -Compress',
+  ].join(' ')
+
+  const { stdout } = await execFileAsync('powershell.exe', [
+    '-NoProfile',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-Command',
+    script,
+  ], {
+    maxBuffer: 2 * 1024 * 1024,
+    timeout: 15_000,
+    windowsHide: true,
+  })
+  return normalizeWindowsDiskPayload(stdout)
+}
+
+export async function scanUsbStorageVolumes(): Promise<UsbStorageVolume[]> {
+  if (process.platform !== 'win32') return []
+
+  const volumes: UsbStorageVolume[] = []
+  let disks: WindowsLogicalDisk[]
+  try {
+    disks = await windowsLogicalDisks()
+  } catch (error) {
+    console.warn('[usb-storage] failed to scan Windows logical disks', error)
+    return []
+  }
+
+  for (const disk of disks) {
+    const deviceId = typeof disk.DeviceID === 'string' ? disk.DeviceID : ''
+    if (!deviceId) continue
+
+    const rootPath = normalizeWindowsDriveRoot(deviceId)
+    const label = typeof disk.VolumeName === 'string' && disk.VolumeName.trim()
+      ? disk.VolumeName.trim()
+      : deviceId
+    const mediaRoot = await resolveMediaRoot(rootPath)
+    const searchText = `${label} ${rootPath} ${mediaRoot ?? ''}`.toLowerCase()
+    const likelyCameraVolume = Boolean(mediaRoot) && (
+      searchText.includes('internal')
+      || searchText.includes('luna')
+      || searchText.includes('insta360')
+      || searchText.includes('dcim')
+    )
+    if (!likelyCameraVolume || !mediaRoot) continue
+
+    volumes.push({
+      storageId: storageIdForVolume(label, rootPath),
+      label,
+      rootPath,
+      mediaRoot,
+      freeBytes: toNumber(disk.FreeSpace),
+      totalBytes: toNumber(disk.Size),
+    })
+  }
+
+  return volumes.sort((a, b) => {
+    const order = (id: string): number => id === 'storage_internal' ? 0 : id === 'sdcard' ? 1 : 2
+    return order(a.storageId) - order(b.storageId) || a.label.localeCompare(b.label)
+  })
+}
+
+export async function scanUsbStorageDevices(): Promise<UsbDeviceCandidate[]> {
+  const volumes = await scanUsbStorageVolumes()
+  return volumes.map((volume) => ({
+    id: `volume:${volume.rootPath}`,
+    name: volume.label,
+    manufacturer: 'Windows Volume',
+    serialNumber: volume.rootPath,
+    busName: 'File Transfer',
+    mountPath: volume.rootPath,
+    storageId: volume.storageId,
+    freeBytes: volume.freeBytes,
+    totalBytes: volume.totalBytes,
+    transport: 'usb',
+    matched: true,
+    source: 'powershell',
+  }))
+}
+
+async function collectMediaFiles(root: string, limit = 5000): Promise<string[]> {
+  const results: string[] = []
+
+  async function walk(dir: string): Promise<void> {
+    if (results.length >= limit) return
+    let entries: import('node:fs').Dirent[]
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+
+    for (const entry of entries) {
+      if (results.length >= limit || entry.name.startsWith('.')) continue
+      const entryPath = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        await walk(entryPath)
+      } else if (entry.isFile() && MEDIA_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
+        results.push(entryPath)
+      }
+    }
+  }
+
+  await walk(root)
+  return results
+}
+
+function previewNameFor(filePath: string): string | null {
+  const parsed = path.parse(filePath)
+  const lrvPath = path.join(parsed.dir, `${parsed.name}.LRV`)
+  return lrvPath
+}
+
+export async function listUsbStorageFiles(storageFilter = 'all'): Promise<LunaFile[]> {
+  const volumes = await scanUsbStorageVolumes()
+  const selected = storageFilter === 'all'
+    ? volumes
+    : volumes.filter((volume) => volume.storageId === storageFilter)
+
+  const files: LunaFile[] = []
+  for (const volume of selected.length > 0 ? selected : volumes) {
+    for (const filePath of await collectMediaFiles(volume.mediaRoot)) {
+      const name = path.basename(filePath)
+      const kind = lunaMediaAdapter.mediaKind(name)
+      if (kind === 'unknown' || kind === 'lrv') continue
+
+      const stats = await fs.stat(filePath)
+      const capturedAt = lunaMediaAdapter.capturedAt(name) ?? stats.mtime
+      const labels = labelsFor(capturedAt)
+      const fileUrl = pathToFileURL(filePath).toString()
+      const previewPath = kind === 'video' ? previewNameFor(filePath) : null
+      const hasPreview = previewPath ? await pathExists(previewPath) : false
+
+      files.push({
+        id: `${volume.storageId}:${filePath}`,
+        storageId: volume.storageId,
+        storageLabel: volume.label,
+        name,
+        href: filePath,
+        sourceUrl: fileUrl,
+        url: fileUrl,
+        dateText: labels.dateText,
+        timeText: labels.timeText,
+        sizeText: String(stats.size),
+        bytes: stats.size,
+        kind,
+        extension: lunaMediaAdapter.extensionOf(name),
+        capturedAt: labels.capturedAt,
+        groupDay: labels.groupDay,
+        groupHour: labels.groupHour,
+        videoKey: lunaMediaAdapter.videoKey(name),
+        previewName: hasPreview && previewPath ? path.basename(previewPath) : null,
+        previewUrl: hasPreview && previewPath ? pathToFileURL(previewPath).toString() : null,
+        cacheFilePath: null,
+        downloadFilePath: null,
+        thumbnailUrl: null,
+        isLivePhoto: Boolean(lunaMediaAdapter.livePhotoKey(name)),
+        livePhotoVideoName: null,
+        livePhotoVideoUrl: null,
+        livePhotoCacheFilePath: null,
+        downloadName: name,
+        canPreview: kind === 'image' || kind === 'video',
+        localPath: filePath,
+      })
+    }
+  }
+
+  return lunaMediaAdapter.attachRelatedFiles(files).sort((a, b) => {
+    const aTime = a.capturedAt ? Date.parse(a.capturedAt) : 0
+    const bTime = b.capturedAt ? Date.parse(b.capturedAt) : 0
+    return bTime - aTime || a.name.localeCompare(b.name)
+  })
+}
+
+export function usbStorageOptions(volumes: UsbStorageVolume[]): DeviceStorageOption[] {
+  return volumes.map((volume) => ({
+    id: volume.storageId,
+    label: volume.storageId === 'storage_internal' ? '内置存储' : volume.label,
+    path: volume.mediaRoot,
+    default: volume.storageId === 'storage_internal',
+  }))
+}

--- a/src/context/DeviceConnectionContext.tsx
+++ b/src/context/DeviceConnectionContext.tsx
@@ -4,6 +4,7 @@ import { useApp } from './AppContext'
 import { logger } from '../lib/rendererLogger'
 import type {
   AppSettings,
+  ConnectionMode,
   ConnectionStatus,
   DeviceConnectionPhase,
   DeviceDefinition,
@@ -13,7 +14,7 @@ import type {
 interface DeviceConnectionContextValue {
   activeDevice: DeviceDefinition | undefined
   cameraLibraryMounted: boolean
-  connectDevice: () => Promise<void>
+  connectDevice: (mode?: ConnectionMode) => Promise<void>
   devices: DeviceDefinition[]
   devicePhase: DeviceConnectionPhase
   isConnected: boolean
@@ -35,9 +36,9 @@ function activeDeviceFor(settings: AppSettings | null, devices: DeviceDefinition
   return devices.find((device) => device.id === settings?.activeDeviceId) ?? firstDevice(devices)
 }
 
-function connectionTimeoutStatus(host: string): Promise<ConnectionStatus> {
+function connectionTimeoutStatus(host: string, mode: ConnectionMode): Promise<ConnectionStatus> {
   return new Promise((resolve) => {
-    setTimeout(() => resolve({ host, httpOk: false, controlOk: false, message: '连接超时' }), 4000)
+    setTimeout(() => resolve({ host, httpOk: false, controlOk: false, mode, message: '连接超时' }), 4000)
   })
 }
 
@@ -84,7 +85,7 @@ export function DeviceConnectionProvider({ children }: { children: ReactNode }) 
   const [cameraLibraryMounted, setCameraLibraryMounted] = useState(false)
 
   const activeDevice = useMemo(() => activeDeviceFor(settings, devices), [devices, settings])
-  const isConnected = devicePhase === 'connected' && Boolean(connection?.httpOk && connection.controlOk)
+  const isConnected = devicePhase === 'connected' && Boolean((connection?.httpOk && connection.controlOk) || connection?.usbOk)
   const showDeviceConnect = !isConnected
 
   useEffect(() => {
@@ -113,7 +114,7 @@ export function DeviceConnectionProvider({ children }: { children: ReactNode }) 
     return window.luna.onConnectionLost(() => {
       const host = settings?.cameraHost || activeDevice?.defaultHost || ''
       logger.warn('[设备连接] 连接丢失', { host })
-      setConnection({ host, httpOk: false, controlOk: false, message: '设备连接已断开' })
+      setConnection({ host, httpOk: false, controlOk: false, mode: settings?.connectionMode ?? 'wifi', message: '设备连接已断开' })
       setDevicePhase('error')
       void window.luna.disconnect()
     })
@@ -124,15 +125,23 @@ export function DeviceConnectionProvider({ children }: { children: ReactNode }) 
     if (!showDeviceConnect) setCameraLibraryMounted(true)
   }, [showDeviceConnect])
 
-  async function connectDevice(): Promise<void> {
+  async function connectDevice(modeOverride?: ConnectionMode): Promise<void> {
     try {
       const deviceId = settings?.activeDeviceId ?? activeDevice?.id
-      const host = settings?.cameraHost ?? activeDevice?.defaultHost
-      logger.info('[设备连接] 发起连接', { deviceId, host })
-      if (!deviceId || !host) {
-        const errMsg = '未配置设备连接地址'
+      const mode = modeOverride ?? settings?.connectionMode ?? 'wifi'
+      const host = settings?.cameraHost || activeDevice?.defaultHost || ''
+      logger.info('[设备连接] 发起连接', { deviceId, host, mode })
+      if (!deviceId) {
+        const errMsg = '未配置设备'
         logger.warn('[设备连接] 无法连接', { deviceId, host, error: errMsg })
-        setConnection({ host: host ?? '', httpOk: false, controlOk: false, message: errMsg })
+        setConnection({ host, httpOk: false, controlOk: false, mode, message: errMsg })
+        setDevicePhase('error')
+        return
+      }
+      if (mode === 'wifi' && !host) {
+        const errMsg = '未配置设备连接地址'
+        logger.warn('[设备连接] 无法连接', { deviceId, host, mode, error: errMsg })
+        setConnection({ host, httpOk: false, controlOk: false, mode, message: errMsg })
         setDevicePhase('error')
         return
       }
@@ -140,23 +149,26 @@ export function DeviceConnectionProvider({ children }: { children: ReactNode }) 
       setDevicePhase('checking')
       const t0 = performance.now()
       const status = await Promise.race([
-        window.luna.connectDevice({ deviceId, host }),
-        connectionTimeoutStatus(host),
+        window.luna.connectDevice({ deviceId, host, mode }),
+        connectionTimeoutStatus(mode === 'usb' ? '本地 USB' : host, mode),
       ])
       const elapsed = ((performance.now() - t0) / 1000).toFixed(2)
-      const enrichedStatus = status.httpOk && status.controlOk ? status : await enrichConnectionStatus(status)
+      const enrichedStatus = status.usbOk || (status.httpOk && status.controlOk) ? status : await enrichConnectionStatus(status)
       setConnection(enrichedStatus)
-      if (enrichedStatus.httpOk && enrichedStatus.controlOk) {
+      setSettings(await window.luna.getSettings())
+      if ((enrichedStatus.httpOk && enrichedStatus.controlOk) || enrichedStatus.usbOk) {
         setDevicePhase('connected')
         setCameraLibraryMounted(false)
-        logger.info('[设备连接] 连接成功', { deviceId, host, elapsedSec: elapsed })
+        logger.info('[设备连接] 连接成功', { deviceId, host, mode, elapsedSec: elapsed })
       } else {
         setDevicePhase('error')
         logger.warn('[设备连接] 连接失败', {
           deviceId,
           host,
+          mode,
           httpOk: enrichedStatus.httpOk,
           controlOk: enrichedStatus.controlOk,
+          usbOk: enrichedStatus.usbOk,
           message: enrichedStatus.message,
           elapsedSec: elapsed,
           diagnosticsRaw: enrichedStatus.diagnosticsRaw,
@@ -166,7 +178,7 @@ export function DeviceConnectionProvider({ children }: { children: ReactNode }) 
       const host = settings?.cameraHost || activeDevice?.defaultHost || ''
       const errMsg = error instanceof Error ? error.message : String(error)
       logger.error('[设备连接] 连接异常', { host, error: errMsg })
-      setConnection({ host, httpOk: false, controlOk: false, message: errMsg })
+      setConnection({ host, httpOk: false, controlOk: false, mode: settings?.connectionMode ?? 'wifi', message: errMsg })
       setDevicePhase('error')
     }
   }

--- a/src/pages/DeviceConnectPage.tsx
+++ b/src/pages/DeviceConnectPage.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react'
-import { Check, CheckCircle2, Copy, HelpCircle, MonitorCog, PlugZap, RefreshCw } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Cable, Check, CheckCircle2, Copy, HelpCircle, MonitorCog, PlugZap, RefreshCw } from 'lucide-react'
 
-import type { AppSettings, ConnectionStatus, DeviceConnectionPhase, DeviceDefinition } from '../shared/types'
-import { Alert, Button } from '../ui'
+import type { AppSettings, ConnectionMode, ConnectionStatus, DeviceConnectionPhase, DeviceDefinition, UsbDeviceCandidate } from '../shared/types'
+import { Alert, Button, SegmentedControl } from '../ui'
 import { HelpDialog } from '../components/HelpDialog'
 import '../styles/wifi.css'
 import lunaIcon from '/luna-icon.png'
@@ -12,7 +12,7 @@ interface DeviceConnectPageProps {
   connection: ConnectionStatus | null
   phase: DeviceConnectionPhase
   settings: AppSettings | null
-  onConnect: () => Promise<void>
+  onConnect: (mode?: ConnectionMode) => Promise<void>
 }
 
 export function DeviceConnectPage({
@@ -23,10 +23,16 @@ export function DeviceConnectPage({
   onConnect,
 }: DeviceConnectPageProps) {
   const [connecting, setConnecting] = useState(false)
+  const [usbScanning, setUsbScanning] = useState(false)
+  const [usbDevices, setUsbDevices] = useState<UsbDeviceCandidate[]>([])
+  const [usbMessage, setUsbMessage] = useState('正在检测数据线连接...')
+  const [selectedMode, setSelectedMode] = useState<ConnectionMode>(settings?.connectionMode ?? 'wifi')
   const [diagnosticsCopied, setDiagnosticsCopied] = useState(false)
+  const connectionMode = selectedMode
   const isChecking = phase === 'checking'
   const isError = phase === 'error'
   const deviceName = activeDevice?.name ?? '设备'
+  const displayHost = settings?.cameraHost || activeDevice?.defaultHost || '未配置'
   const deviceInfo = connection?.deviceInfo
   const infoRows = [
     ['设备', deviceInfo?.deviceName],
@@ -35,10 +41,32 @@ export function DeviceConnectPage({
     ['Wi-Fi', deviceInfo?.ssid],
   ].filter((row): row is [string, string] => Boolean(row[1]))
 
+  useEffect(() => {
+    setSelectedMode(settings?.connectionMode ?? 'wifi')
+  }, [settings?.connectionMode])
+
+  useEffect(() => {
+    void scanUsb()
+  }, [])
+
+  async function scanUsb(): Promise<void> {
+    setUsbScanning(true)
+    try {
+      const devices = await window.luna.scanUsbDevices()
+      setUsbDevices(devices)
+      setUsbMessage(devices.length > 0 ? '已识别到数据线存储或设备' : '暂未识别到数据线存储')
+    } catch {
+      setUsbDevices([])
+      setUsbMessage('暂未识别到数据线存储')
+    } finally {
+      setUsbScanning(false)
+    }
+  }
+
   async function handleConnect(): Promise<void> {
     setConnecting(true)
     try {
-      await onConnect()
+      await onConnect(connectionMode)
     } finally {
       setConnecting(false)
     }
@@ -83,7 +111,7 @@ export function DeviceConnectPage({
         ) : (
           <p className="device-connect-desc">
             {isChecking
-              ? '正在 检测 Wi-Fi 服务并建立控制会话'
+              ? connectionMode === 'usb' ? '正在检测本地 USB 存储' : '正在检测 Wi-Fi 服务并建立控制会话'
               : connection?.message ?? ''}
           </p>
         )}
@@ -91,7 +119,7 @@ export function DeviceConnectPage({
         <div className="device-connect-meta">
           <span>
             <PlugZap size={14} />
-            {settings?.cameraHost ?? activeDevice?.defaultHost ?? '未配置'}
+            {connectionMode === 'usb' ? '本地 USB' : displayHost}
           </span>
           {connection?.httpOk && connection.controlOk && (
             <span>
@@ -99,6 +127,29 @@ export function DeviceConnectPage({
               已检测到服务
             </span>
           )}
+          {connection?.usbOk && (
+            <span>
+              <CheckCircle2 size={14} />
+              已检测到 {connection.usbStorageCount ?? 0} 个数据线存储
+            </span>
+          )}
+        </div>
+
+        <div className="device-connect-mode">
+          <SegmentedControl<ConnectionMode>
+            ariaLabel="选择连接方式"
+            options={[
+              { value: 'wifi', label: 'Wi-Fi' },
+              { value: 'usb', label: '本地 USB' },
+            ]}
+            value={connectionMode}
+            onChange={(value) => {
+              setSelectedMode(value)
+              void window.luna.saveSettings({ connectionMode: value }).then(() => {
+                if (value === 'usb') void scanUsb()
+              })
+            }}
+          />
         </div>
 
         {infoRows.length > 0 && (
@@ -136,14 +187,57 @@ export function DeviceConnectPage({
             disabled={connecting || isChecking}
             icon={connecting || isChecking ? <RefreshCw className="spin" size={16} /> : <RefreshCw size={16} />}
           >
-            {isError ? '重新连接' : '开始连接'}
+            {isError ? '重新连接' : connectionMode === 'usb' ? '连接本地 USB' : '连接 Wi-Fi'}
           </Button>
-          <Button variant="secondary" onClick={() => window.luna.openWifiSettings()} icon={<MonitorCog size={16} />}>
-            打开 Wi-Fi 设置
-          </Button>
+          {connectionMode === 'wifi' && (
+            <Button variant="secondary" onClick={() => window.luna.openWifiSettings()} icon={<MonitorCog size={16} />}>
+              打开 Wi-Fi 设置
+            </Button>
+          )}
+        </div>
+
+        <div className="device-usb-panel">
+          <div className="device-usb-heading">
+            <span>
+              <Cable size={15} />
+              数据线连接
+            </span>
+            <button type="button" onClick={() => void scanUsb()} disabled={usbScanning}>
+              <RefreshCw size={13} className={usbScanning ? 'spin' : undefined} />
+              刷新
+            </button>
+          </div>
+          {usbDevices.length > 0 ? (
+            <div className="device-usb-list">
+              {usbDevices.map((device) => (
+                <div className="device-usb-item" key={device.id}>
+                  <strong>{device.name}</strong>
+                  <span>
+                    {[
+                      device.manufacturer || '未知厂商',
+                      device.mountPath,
+                      device.busName,
+                    ].filter(Boolean).join(' · ')}
+                  </span>
+                  {(device.vendorId || device.productId || device.serialNumber) && (
+                    <em>
+                      {[device.vendorId, device.productId, device.serialNumber].filter(Boolean).join(' · ')}
+                    </em>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="device-usb-empty">{usbMessage}</p>
+          )}
+          <p className="device-usb-note">
+            Windows 文件传输模式会动态识别相机挂载出的内部存储和 SD 卡，不依赖固定盘符。
+          </p>
         </div>
         <p className="device-connect-tip">
-          设备 Wi-Fi 可能无互联网；下载完成后建议切回自己的网络
+          {connectionMode === 'usb'
+            ? '本地 USB 模式会直接读取 Windows 里出现的相机存储'
+            : '设备 Wi-Fi 可能无互联网；下载完成后建议切回自己的网络'}
         </p>
         <div className="device-connect-help">
           <HelpDialog>

--- a/src/pages/useMediaLibraryController.ts
+++ b/src/pages/useMediaLibraryController.ts
@@ -254,7 +254,7 @@ export function useMediaLibraryController({
       thumbnailUrl: file.thumbnailUrl?.slice(0, 300),
       cacheFilePath: file.cacheFilePath,
       downloadFilePath: file.downloadFilePath,
-      localPath: (file as any).localPath,
+      localPath: file.localPath,
     })
     // 缩略图加载失败（如文件损坏），清除请求记录允许重试
     requestedThumbnailIdsRef.current.delete(file.id)
@@ -286,12 +286,15 @@ export function useMediaLibraryController({
     const t0 = performance.now()
     try {
       const host = settings.cameraHost
-      logger.info('[媒体库] 开始从设备加载文件', { host, storageFilter })
-      await window.luna.checkConnection(host)
+      const connectionMode = settings.connectionMode ?? 'wifi'
+      logger.info('[媒体库] 开始从设备加载文件', { host, storageFilter, connectionMode })
+      if (connectionMode !== 'usb') {
+        await window.luna.checkConnection(host)
+      }
       // listFiles 只做轻量本地路径/已有缩略图标记，缓存由渲染层按需发起
       const lunaFiles = await window.luna.listFiles(host, storageFilter)
       const elapsed = ((performance.now() - t0) / 1000).toFixed(2)
-      logger.info('[媒体库] 设备文件加载完成', { host, fileCount: lunaFiles.length, elapsedSec: elapsed, storageFilter })
+      logger.info('[媒体库] 设备文件加载完成', { host, fileCount: lunaFiles.length, elapsedSec: elapsed, storageFilter, connectionMode })
       setFiles(lunaFiles)
       setSelected(new Set())
       setCacheFailedIds(new Set())
@@ -351,6 +354,7 @@ export function useMediaLibraryController({
     if (isDownloadsPage && viewMode === 'export') {
       void loadExportLibrary()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDownloadsPage, viewMode, settings?.exportDir])
 
   const {

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -1,5 +1,5 @@
 import type { AppSettings, CacheStats, AiConfig } from './settings'
-import type { DeviceDefinition, DeviceConnectOptions, ConnectionStatus, BluetoothDeviceCandidate } from './device'
+import type { DeviceDefinition, DeviceConnectOptions, ConnectionStatus, BluetoothDeviceCandidate, UsbDeviceCandidate } from './device'
 import type { LunaFile } from './media'
 import type { PreviewResult, MediaMetadata } from './preview'
 import type { WatermarkSettings } from './watermark'
@@ -42,6 +42,7 @@ export interface LunaApi {
   openDevTools(): Promise<void>
   scanBluetoothDevices(timeoutMs?: number): Promise<BluetoothDeviceCandidate[]>
   cancelBluetoothScan(): Promise<void>
+  scanUsbDevices(): Promise<UsbDeviceCandidate[]>
   connectDevice(options?: DeviceConnectOptions): Promise<ConnectionStatus>
   checkConnection(host?: string): Promise<ConnectionStatus>
   listFiles(host?: string, storageId?: string): Promise<LunaFile[]>

--- a/src/shared/types/device.ts
+++ b/src/shared/types/device.ts
@@ -33,10 +33,14 @@ export interface ConnectionStatus {
   host: string
   httpOk: boolean
   controlOk: boolean
+  mode?: ConnectionMode
+  usbOk?: boolean
+  usbStorageCount?: number
   message: string
 }
 
 export type DeviceConnectionPhase = 'idle' | 'checking' | 'connected' | 'error'
+export type ConnectionMode = 'wifi' | 'usb'
 
 export interface DeviceDefinition {
   id: string
@@ -68,6 +72,7 @@ export interface DeviceDefinition {
 export interface DeviceConnectOptions {
   deviceId?: string
   host?: string
+  mode?: ConnectionMode
   storageId?: string
 }
 
@@ -77,4 +82,22 @@ export interface BluetoothDeviceCandidate {
   rssi?: number
   serviceUuids?: string[]
   localName?: string
+}
+
+export interface UsbDeviceCandidate {
+  id: string
+  name: string
+  manufacturer?: string
+  serialNumber?: string
+  vendorId?: string
+  productId?: string
+  productVersion?: string
+  busName?: string
+  mountPath?: string
+  storageId?: string
+  freeBytes?: number | null
+  totalBytes?: number | null
+  transport: 'usb'
+  matched: boolean
+  source: 'system_profiler' | 'powershell'
 }

--- a/src/shared/types/settings.ts
+++ b/src/shared/types/settings.ts
@@ -12,6 +12,7 @@ export interface AppSettings {
   exportDir?: string
   cacheDir: string
   cameraHost: string
+  connectionMode?: 'wifi' | 'usb'
   activeDeviceId?: string
   deviceStorage?: Record<string, string>
   deviceWatermark?: Record<string, WatermarkSettings>

--- a/src/styles/wifi.css
+++ b/src/styles/wifi.css
@@ -56,6 +56,12 @@
   margin-top: 16px;
 }
 
+.device-connect-mode {
+  display: flex;
+  justify-content: center;
+  margin-top: 4px;
+}
+
 .device-connect-meta {
   display: flex;
   flex-wrap: wrap;
@@ -154,6 +160,92 @@
   overflow-wrap: anywhere;
   font-size: 11px;
   line-height: 1.45;
+}
+
+.device-usb-panel {
+  display: grid;
+  width: min(100%, 420px);
+  gap: 10px;
+  margin-top: 6px;
+  border: 1px solid var(--hairline);
+  border-radius: 8px;
+  background: var(--canvas);
+  padding: 12px;
+  text-align: left;
+}
+
+.device-usb-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.device-usb-heading span,
+.device-usb-heading button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.device-usb-heading button {
+  border: 1px solid var(--hairline);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 5px 8px;
+}
+
+.device-usb-heading button:hover {
+  color: var(--ink);
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.device-usb-heading button:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.device-usb-list {
+  display: grid;
+  gap: 8px;
+}
+
+.device-usb-item {
+  display: grid;
+  gap: 3px;
+  border: 1px solid var(--hairline);
+  border-radius: 8px;
+  padding: 9px 10px;
+}
+
+.device-usb-item strong {
+  color: var(--ink);
+  font-size: 13px;
+}
+
+.device-usb-item span,
+.device-usb-item em,
+.device-usb-empty,
+.device-usb-note {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.device-usb-item em {
+  font-style: normal;
+  overflow-wrap: anywhere;
+}
+
+.device-usb-empty,
+.device-usb-note {
+  margin: 0;
 }
 
 .device-connect-tip {


### PR DESCRIPTION
## 概要

为 Luna 媒体浏览增加 Windows 本地 USB / 数据线连接模式，与现有 Wi-Fi 连接流程并行使用。

## 变更内容

- 新增 USB 设备扫描与 Windows 存储卷扫描服务。
- 通过 Electron preload API 暴露 `scanUsbDevices`。
- 增加 `connectionMode` 设置，支持用户在 Wi-Fi 与本地 USB 之间切换。
- USB 模式下直接读取 Windows 中识别到的相机存储卷媒体文件。
- 更新设备连接页，增加 Wi-Fi / 本地 USB 分段选择器和已识别 USB 存储列表。

## 验证

- `corepack pnpm exec tsc --noEmit`
- 变更文件 ESLint 检查
- `corepack pnpm run build:app`

说明：仓库全量 lint 当前仍有上游既有无关问题，因此本次验证使用了变更文件 lint、TypeScript 检查和应用构建。